### PR TITLE
Inline Widgets

### DIFF
--- a/src/dashboard/widgets/bar_chart.py
+++ b/src/dashboard/widgets/bar_chart.py
@@ -19,11 +19,12 @@ class BarChartWidget(WidgetInterface):
         # Create the chart
         fig = go.Figure([go.Bar(x=x, y=y)])
 
-        fig.update_layout(title = str(self.data_type) + " Progress")
+        # To be used in the future
+        fig.update_layout(legend_title_text = "Activity")
         fig.update_xaxes(title_text="Time")
-        fig.update_yaxes(title_text=str(self.data_type))
-
-        return html.Div(children=[
+        fig.update_yaxes(title_text="Data Type")
+        
+        return html.Div(style={'width': '50%', 'padding': '1.5em', 'display': 'inline-block'}, children = [
             dbc.Card("Widget: " + self.name, body=True),
             dcc.Graph(figure=fig)
         ])

--- a/src/dashboard/widgets/gauge_chart.py
+++ b/src/dashboard/widgets/gauge_chart.py
@@ -37,7 +37,7 @@ class GaugeChartWidget(WidgetInterface):
                                               gauge = {'axis': {'range': [None, self.goal + 50]},
                                                      'threshold' : {'line': {'color': "red", 'width': 4}, 'thickness': 0.75, 'value': self.goal}}))
 
-        return html.Div(children=[
+        return html.Div(style={'width': '50%', 'padding': '1.5em', 'display': 'inline-block'}, children=[
             dbc.Card("Widget: " + self.name, body=True),
             dcc.Graph(figure=fig)
         ])

--- a/src/dashboard/widgets/line_chart.py
+++ b/src/dashboard/widgets/line_chart.py
@@ -23,7 +23,7 @@ class LineChartWidget(WidgetInterface):
         fig.update_xaxes(title_text="Time")
         fig.update_yaxes(title_text=str(self.data_type))
 
-        return html.Div(children=[
+        return html.Div(style={'width': '50%', 'padding': '1.5em', 'display': 'inline-block'}, children = [
             dbc.Card("Widget: " + self.name, body=True),
-            dcc.Graph(figure=fig)
+            dcc.Graph(figure=fig)        
         ])

--- a/src/dashboard/widgets/radar_chart.py
+++ b/src/dashboard/widgets/radar_chart.py
@@ -42,7 +42,7 @@ class RadarChartWidget(WidgetInterface):
 
         fig.update_layout(title = "Goal Progress")
 
-        return html.Div(children=[
+        return html.Div(style={'width': '50%', 'padding': '1.5em', 'display': 'inline-block'}, children=[
             dbc.Card("Widget: " + self.name, body=True),
             dcc.Graph(figure=fig)
         ])

--- a/src/dashboard/widgets/scatter_plot.py
+++ b/src/dashboard/widgets/scatter_plot.py
@@ -23,7 +23,7 @@ class ScatterPlotWidget(WidgetInterface):
         fig.update_xaxes(title_text="Time")
         fig.update_yaxes(title_text=str(self.data_type))
 
-        return html.Div(children=[
+        return html.Div(style={'width': '50%', 'padding': '1.5em', 'display': 'inline-block'}, children = [
             dbc.Card("Widget: " + self.name, body=True),
             dcc.Graph(figure=fig)
         ])

--- a/src/dashboard/widgets/stats_card.py
+++ b/src/dashboard/widgets/stats_card.py
@@ -61,7 +61,9 @@ class StatsCardWidget(WidgetInterface):
                 html.H4(max_date.strftime("%b %d %Y"), style={'text-align': 'center'}, id='max-date')
             ])
 
-        return dbc.Card([
+        stats_card = dbc.Card(children = [
             dbc.CardHeader(html.H4(self.name)),
             dbc.CardBody(body)
         ])
+
+        return html.Div(style={'width': '50%', 'padding': '1.5em', 'float': 'left', 'display': 'inline-block'}, children = [stats_card])

--- a/tests/test_stats_card.py
+++ b/tests/test_stats_card.py
@@ -51,7 +51,7 @@ class TestStatsCard:
         assert self.mock_data_manager.get_data.called_with('Distance', '2022-04-04', '15min')
 
         # Verify the output content
-        assert type(widget_output) == dbc.Card
+        assert type(widget_output) == html.Div
         assert len(widget_output.children) == 2
         header = widget_output.children[0]
         assert type(header) == dbc.CardHeader

--- a/tests/test_stats_card.py
+++ b/tests/test_stats_card.py
@@ -24,13 +24,13 @@ class TestStatsCard:
         assert self.mock_data_manager.get_data.called_with('Steps', '2022-04-01', '2022-04-04')
 
         # Verify the output content
-        assert type(widget_output) == dbc.Card
-        assert len(widget_output.children) == 2
-        header = widget_output.children[0]
+        assert type(widget_output) == html.Div
+        assert len(widget_output.children) == 1
+        header = widget_output.children[0].children[0]
         assert type(header) == dbc.CardHeader
         assert type(header.children) == html.H4
         assert header.children.children == 'Test Stats Card'
-        body = widget_output.children[1].children.children
+        body = widget_output.children[0].children[1].children.children
         body_data = {x.id:x.children for x in body if hasattr(x, 'id')}
         assert body_data['total'].split() == ['6000', 'Steps']
         assert body_data['average'].split() == ['2000', 'Steps']
@@ -52,12 +52,12 @@ class TestStatsCard:
 
         # Verify the output content
         assert type(widget_output) == html.Div
-        assert len(widget_output.children) == 2
-        header = widget_output.children[0]
+        assert len(widget_output.children) == 1
+        header = widget_output.children[0].children[0]
         assert type(header) == dbc.CardHeader
         assert type(header.children) == html.H4
         assert header.children.children == 'Test Stats Card'
-        body = widget_output.children[1].children.children
+        body = widget_output.children[0].children[1].children.children
         body_data = {x.id:x.children for x in body if hasattr(x, 'id')}
         assert body_data['total'].split() == ['1', 'Miles']
         assert body_data['average'].split() == ['0.333', 'Miles']


### PR DESCRIPTION
Widgets now appear inline. This was done without using bootstrap rows/columns. The graphs/card are styled with `{display: 'inline-block', 'width': '50%'}`. The card specifically has an additional CSS styling `'float': 'left'` because it wasn't playing nicely with the inline graphs.