### PR TITLE
CI Linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,8 @@ jobs:
       - name: Install Dependencies
         run: pip install -r src/requirements.txt -r tests/requirements.txt
 
+      - name: Run Linter
+        run: make lint
+        
       - name: Run Unit Tests
         run: pytest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+fmt:
+	autoflake -i -r --expand-star-imports --remove-all-unused-imports --ignore-init-module-imports --remove-unused-variables . --exclude __init__ \
+	&& autopep8 -i -r --exclude __init__.py . \
+	&& isort --skip __init__.py -y \
+	&& black .
+
+lint:
+	autoflake -c -r --expand-star-imports --remove-all-unused-imports --ignore-init-module-imports --remove-unused-variables . --exclude __init__ \
+	&& isort --skip __init__.py --check-only \
+	&& black . --check \

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,8 @@
+autoflake==1.4
+black==22.3.0
 dash==2.3.0
+isort==5.10.1
+flake8==4.0.1
 fitbit==0.3.1
 dash-bootstrap-components==1.0.3
 gunicorn==20.1.0


### PR DESCRIPTION
This will check for proper formatting on PR's that are getting put up. If the CI tests fail for any linting error, run `make fmt`. This will automatically tweak the your newly-added code to adhere to the linting standards.