### PR TITLE
added trendline features

### DIFF
--- a/src/dashboard/widget_modal.py
+++ b/src/dashboard/widget_modal.py
@@ -132,10 +132,16 @@ class WidgetModal:
                                 updatemode="drag",
                             ),
                             html.Br(),
-                            dbc.Label("Select A Trendline (Only allowed for Bar, Line, and Scatter Charts)",
-                                      html_for="trendline"),
-                            dcc.RadioItems(['Rolling Average', 'Linear', 'None'], 'None', inline=True,
-                                           id='trendline'),
+                            dbc.Label(
+                                "Select A Trendline (Only allowed for Bar, Line, and Scatter Charts)",
+                                html_for="trendline",
+                            ),
+                            dcc.RadioItems(
+                                ["Rolling Average", "Linear", "None"],
+                                "None",
+                                inline=True,
+                                id="trendline",
+                            ),
                         ]
                     )
                 ),
@@ -153,7 +159,7 @@ class WidgetModal:
                 Output("dashboard-selection", "options"),
                 Output("content-wrapper", "children"),
                 Output("alert-auto", "is_open"),
-                Output("trendline", "value")
+                Output("trendline", "value"),
             ],
             [
                 trigger,
@@ -184,13 +190,22 @@ class WidgetModal:
             trends,
             is_open,
         ):
-            if trends == 'None':
+            if trends == "None":
                 trends = None
             changed_id = [p["prop_id"] for p in callback_context.triggered][0]
             # If the user has selected a chart or trend, verify that these are a valid pair
-            if ("chart-type" in changed_id or "trendline" in changed_id) and trends is not None and \
-                chart_type not in ['Line Chart', 'Bar Chart', 'Scatter Plot']:
-                return dash.no_update, dash.no_update, dash.no_update, dash.no_update, "None"
+            if (
+                ("chart-type" in changed_id or "trendline" in changed_id)
+                and trends is not None
+                and chart_type not in ["Line Chart", "Bar Chart", "Scatter Plot"]
+            ):
+                return (
+                    dash.no_update,
+                    dash.no_update,
+                    dash.no_update,
+                    dash.no_update,
+                    "None",
+                )
             # If the widget is not opened but the open button was pressed, open the widget modal
             if widget_open and not is_open:
                 # Updates the dashboard list in case user has added new dashboards
@@ -200,19 +215,31 @@ class WidgetModal:
                         {"label": d.dashid, "value": d.parent_tab.tab_id}
                         for d in self.tabs.dashboards.values()
                     ],
-                    dash.no_update, False, dash.no_update
+                    dash.no_update,
+                    False,
+                    dash.no_update,
                 )
             # If submit was pressed, create a widget from the selected input
             if "submit" in changed_id:
-                if start_date is None or end_date is None or widget_name is None \
-                        or (trends is not None and chart_type not in ['Line Chart', 'Bar Chart', 'Scatter Plot']):
+                if (
+                    start_date is None
+                    or end_date is None
+                    or widget_name is None
+                    or (
+                        trends is not None
+                        and chart_type
+                        not in ["Line Chart", "Bar Chart", "Scatter Plot"]
+                    )
+                ):
                     return (
                         is_open,
                         [
                             {"label": d.dashid, "value": d.parent_tab.tab_id}
                             for d in self.tabs.dashboards.values()
                         ],
-                        dash.no_update, True, dash.no_update
+                        dash.no_update,
+                        True,
+                        dash.no_update,
                     )
                 if trends:
                     tabs.dashboards[dashboard].widgets.append(
@@ -223,7 +250,7 @@ class WidgetModal:
                             end_date,
                             widget_name,
                             goal,
-                            trends
+                            trends,
                         )
                     )
                 else:
@@ -237,7 +264,13 @@ class WidgetModal:
                             goal,
                         )
                     )
-                return not is_open, dash.no_update, tabs.render_content(), False, dash.no_update
+                return (
+                    not is_open,
+                    dash.no_update,
+                    tabs.render_content(),
+                    False,
+                    dash.no_update,
+                )
             # Essentially a no update, case where neither submit nor open was clicked, typically from callback being called on refresh of page
             return (
                 is_open,
@@ -245,7 +278,9 @@ class WidgetModal:
                     {"label": d.dashid, "value": d.parent_tab.tab_id}
                     for d in self.tabs.dashboards.values()
                 ],
-                dash.no_update, False, dash.no_update
+                dash.no_update,
+                False,
+                dash.no_update,
             )
 
         @app.callback(

--- a/src/dashboard/widgets/bar_chart.py
+++ b/src/dashboard/widgets/bar_chart.py
@@ -1,13 +1,16 @@
 import dash_bootstrap_components as dbc
 import plotly.graph_objects as go
+import plotly.express as px
 from dash import dcc, html
+import datetime
 
 from .widget_interface import WidgetInterface
 
 
 class BarChartWidget(WidgetInterface):
-    def __init__(self, data_manager, data_type, start_date, end_date, name, goal):
+    def __init__(self, data_manager, data_type, start_date, end_date, name, goal, trends):
         super().__init__(data_manager, data_type, start_date, end_date, name, goal)
+        self.trends = trends
 
     def render(self):
         # Get the data first
@@ -15,10 +18,26 @@ class BarChartWidget(WidgetInterface):
             self.data_type, self.start_date, self.end_date
         )
         y = data[self.data_type]
-        x = data["Time"]
+        if self.intraday:
+            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data['Time']]
+        else:
+            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data['Time']]
 
         # Create the chart
         fig = go.Figure([go.Bar(x=x, y=y)])
+
+        # Bar charts do not support trendlines so we will get the trend data from a
+        # helper figure and copy it over onto our original plot
+        if self.trends is not None:
+            if self.trends == 'Linear':
+                scat = px.scatter(x=x, y=y, trendline="ols", trendline_scope="overall",
+                                  trendline_color_override='red')
+            else:
+                scat = px.scatter(x=x, y=y, trendline='rolling', trendline_options={'window':int(len(x)/8)},
+                                  trendline_color_override='red')
+            x_trend = scat["data"][1]['x']
+            y_trend = scat["data"][1]['y']
+            fig.add_trace(go.Scatter(x=x_trend, y=y_trend))
 
         # To be used in the future
         fig.update_layout(legend_title_text="Activity")

--- a/src/dashboard/widgets/bar_chart.py
+++ b/src/dashboard/widgets/bar_chart.py
@@ -8,7 +8,9 @@ from .widget_interface import WidgetInterface
 
 
 class BarChartWidget(WidgetInterface):
-    def __init__(self, data_manager, data_type, start_date, end_date, name, goal, trends):
+    def __init__(
+        self, data_manager, data_type, start_date, end_date, name, goal, trends
+    ):
         super().__init__(data_manager, data_type, start_date, end_date, name, goal)
         self.trends = trends
 
@@ -19,9 +21,9 @@ class BarChartWidget(WidgetInterface):
         )
         y = data[self.data_type]
         if self.intraday:
-            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data['Time']]
+            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data["Time"]]
         else:
-            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data['Time']]
+            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data["Time"]]
 
         # Create the chart
         fig = go.Figure([go.Bar(x=x, y=y)])
@@ -29,14 +31,24 @@ class BarChartWidget(WidgetInterface):
         # Bar charts do not support trendlines so we will get the trend data from a
         # helper figure and copy it over onto our original plot
         if self.trends is not None:
-            if self.trends == 'Linear':
-                scat = px.scatter(x=x, y=y, trendline="ols", trendline_scope="overall",
-                                  trendline_color_override='red')
+            if self.trends == "Linear":
+                scat = px.scatter(
+                    x=x,
+                    y=y,
+                    trendline="ols",
+                    trendline_scope="overall",
+                    trendline_color_override="red",
+                )
             else:
-                scat = px.scatter(x=x, y=y, trendline='rolling', trendline_options={'window':int(len(x)/8)},
-                                  trendline_color_override='red')
-            x_trend = scat["data"][1]['x']
-            y_trend = scat["data"][1]['y']
+                scat = px.scatter(
+                    x=x,
+                    y=y,
+                    trendline="rolling",
+                    trendline_options={"window": int(len(x) / 8)},
+                    trendline_color_override="red",
+                )
+            x_trend = scat["data"][1]["x"]
+            y_trend = scat["data"][1]["y"]
             fig.add_trace(go.Scatter(x=x_trend, y=y_trend))
 
         # To be used in the future

--- a/src/dashboard/widgets/line_chart.py
+++ b/src/dashboard/widgets/line_chart.py
@@ -1,13 +1,15 @@
 import dash_bootstrap_components as dbc
-import plotly.graph_objects as go
+import plotly.express as px
 from dash import dcc, html
+import datetime
 
 from .widget_interface import WidgetInterface
 
 
 class LineChartWidget(WidgetInterface):
-    def __init__(self, data_manager, data_type, start_date, end_date, name, goal):
+    def __init__(self, data_manager, data_type, start_date, end_date, name, goal, trends):
         super().__init__(data_manager, data_type, start_date, end_date, name, goal)
+        self.trends = trends
 
     def render(self):
         # Get the data first
@@ -15,11 +17,22 @@ class LineChartWidget(WidgetInterface):
             self.data_type, self.start_date, self.end_date
         )
         y = data[self.data_type]
-        x = data["Time"]
+        if self.intraday:
+            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data['Time']]
+        else:
+            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data['Time']]
 
         # Create the chart
-        fig = go.Figure(data=go.Scatter(x=x, y=y))
+        if self.trends is None:
+            fig = px.scatter(x=x, y=y)
+        elif self.trends == 'Linear':
+            fig = px.scatter(x=x, y=y, trendline="ols", trendline_scope="overall",
+                             trendline_color_override='red')
+        elif self.trends == 'Rolling Average':
+            fig = px.scatter(x=x, y=y, trendline='rolling', trendline_options={'window':int(len(x)/8)},
+                             trendline_color_override='red')
 
+        fig.update_traces(mode='lines')
         fig.update_layout(title=str(self.data_type) + " Progress")
         fig.update_xaxes(title_text="Time")
         fig.update_yaxes(title_text=str(self.data_type))

--- a/src/dashboard/widgets/line_chart.py
+++ b/src/dashboard/widgets/line_chart.py
@@ -7,7 +7,9 @@ from .widget_interface import WidgetInterface
 
 
 class LineChartWidget(WidgetInterface):
-    def __init__(self, data_manager, data_type, start_date, end_date, name, goal, trends):
+    def __init__(
+        self, data_manager, data_type, start_date, end_date, name, goal, trends
+    ):
         super().__init__(data_manager, data_type, start_date, end_date, name, goal)
         self.trends = trends
 
@@ -18,21 +20,31 @@ class LineChartWidget(WidgetInterface):
         )
         y = data[self.data_type]
         if self.intraday:
-            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data['Time']]
+            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data["Time"]]
         else:
-            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data['Time']]
+            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data["Time"]]
 
         # Create the chart
         if self.trends is None:
             fig = px.scatter(x=x, y=y)
-        elif self.trends == 'Linear':
-            fig = px.scatter(x=x, y=y, trendline="ols", trendline_scope="overall",
-                             trendline_color_override='red')
-        elif self.trends == 'Rolling Average':
-            fig = px.scatter(x=x, y=y, trendline='rolling', trendline_options={'window':int(len(x)/8)},
-                             trendline_color_override='red')
+        elif self.trends == "Linear":
+            fig = px.scatter(
+                x=x,
+                y=y,
+                trendline="ols",
+                trendline_scope="overall",
+                trendline_color_override="red",
+            )
+        elif self.trends == "Rolling Average":
+            fig = px.scatter(
+                x=x,
+                y=y,
+                trendline="rolling",
+                trendline_options={"window": int(len(x) / 8)},
+                trendline_color_override="red",
+            )
 
-        fig.update_traces(mode='lines')
+        fig.update_traces(mode="lines")
         fig.update_layout(title=str(self.data_type) + " Progress")
         fig.update_xaxes(title_text="Time")
         fig.update_yaxes(title_text=str(self.data_type))

--- a/src/dashboard/widgets/scatter_plot.py
+++ b/src/dashboard/widgets/scatter_plot.py
@@ -7,7 +7,9 @@ from .widget_interface import WidgetInterface
 
 
 class ScatterPlotWidget(WidgetInterface):
-    def __init__(self, data_manager, data_type, start_date, end_date, name, goal, trends):
+    def __init__(
+        self, data_manager, data_type, start_date, end_date, name, goal, trends
+    ):
         super().__init__(data_manager, data_type, start_date, end_date, name, goal)
         self.trends = trends
 
@@ -18,19 +20,29 @@ class ScatterPlotWidget(WidgetInterface):
         )
         y = data[self.data_type]
         if self.intraday:
-            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data['Time']]
+            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data["Time"]]
         else:
-            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data['Time']]
+            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data["Time"]]
 
         # Create the chart
         if self.trends is None:
             fig = px.scatter(x=x, y=y)
-        elif self.trends == 'Linear':
-            fig = px.scatter(x=x, y=y, trendline="ols", trendline_scope="overall",
-                             trendline_color_override='red')
-        elif self.trends == 'Rolling Average':
-            fig = px.scatter(x=x, y=y, trendline='rolling', trendline_options={'window':int(len(x)/8)},
-                             trendline_color_override='red')
+        elif self.trends == "Linear":
+            fig = px.scatter(
+                x=x,
+                y=y,
+                trendline="ols",
+                trendline_scope="overall",
+                trendline_color_override="red",
+            )
+        elif self.trends == "Rolling Average":
+            fig = px.scatter(
+                x=x,
+                y=y,
+                trendline="rolling",
+                trendline_options={"window": int(len(x) / 8)},
+                trendline_color_override="red",
+            )
 
         fig.update_layout(title=str(self.data_type) + " Progress")
         fig.update_xaxes(title_text="Time")

--- a/src/dashboard/widgets/scatter_plot.py
+++ b/src/dashboard/widgets/scatter_plot.py
@@ -1,13 +1,15 @@
 import dash_bootstrap_components as dbc
-import plotly.graph_objects as go
 from dash import dcc, html
+import plotly.express as px
+import datetime
 
 from .widget_interface import WidgetInterface
 
 
 class ScatterPlotWidget(WidgetInterface):
-    def __init__(self, data_manager, data_type, start_date, end_date, name, goal):
+    def __init__(self, data_manager, data_type, start_date, end_date, name, goal, trends):
         super().__init__(data_manager, data_type, start_date, end_date, name, goal)
+        self.trends = trends
 
     def render(self):
         # Get the data first
@@ -15,10 +17,20 @@ class ScatterPlotWidget(WidgetInterface):
             self.data_type, self.start_date, self.end_date
         )
         y = data[self.data_type]
-        x = data["Time"]
+        if self.intraday:
+            x = [datetime.datetime.strptime(d, "%H:%M:%S") for d in data['Time']]
+        else:
+            x = [datetime.datetime.strptime(d, "%Y-%m-%d") for d in data['Time']]
 
         # Create the chart
-        fig = go.Figure(data=go.Scatter(x=x, y=y, mode="markers"))
+        if self.trends is None:
+            fig = px.scatter(x=x, y=y)
+        elif self.trends == 'Linear':
+            fig = px.scatter(x=x, y=y, trendline="ols", trendline_scope="overall",
+                             trendline_color_override='red')
+        elif self.trends == 'Rolling Average':
+            fig = px.scatter(x=x, y=y, trendline='rolling', trendline_options={'window':int(len(x)/8)},
+                             trendline_color_override='red')
 
         fig.update_layout(title=str(self.data_type) + " Progress")
         fig.update_xaxes(title_text="Time")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,3 +8,5 @@ gunicorn==20.1.0
 cherrypy==18.6.1
 werkzeug==2.0.0
 dash_bootstrap_templates==1.0.5
+pandas==1.4.2
+statsmodels==0.13.1

--- a/tests/test_bar_chart.py
+++ b/tests/test_bar_chart.py
@@ -15,6 +15,7 @@ class TestBarChartWidget:
             "2022-04-04",
             "Test Bar Chart",
             0,
+            None
         )
 
         self.mock_data_manager.get_data.return_value = {

--- a/tests/test_bar_chart.py
+++ b/tests/test_bar_chart.py
@@ -15,7 +15,7 @@ class TestBarChartWidget:
             "2022-04-04",
             "Test Bar Chart",
             0,
-            None
+            None,
         )
 
         self.mock_data_manager.get_data.return_value = {


### PR DESCRIPTION
Users can now add trendlines to bar, line, and scatter plots. To prevent users from trying to add trendlines to conflicting chart types or charts that can't support trendlines, the modal is also updated to prevent the user from selecting any trendlines when the chart type is not Line, Bar, or Scatter.