### PR TITLE
mounted localtime file to synchronize timezone with host machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Dependencies
-        run: pip install -r src/requirements.txt -r tests/requirements.txt
+        run: pip install -r src/requirements.txt -r tests/requirements.txt -r fmt-requirements.txt
 
       - name: Run Linter
         run: make lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./src:/usr/src
+      - /etc/localtime:/etc/localtime


### PR DESCRIPTION
# Description

To fix Issue #114 we needed to synchronize timezones with the host machine when building our docker container by mounting the localtime file as a volume.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Issue

- Pull Request is for **Issue**: #114 


